### PR TITLE
fix: Multiple variables in paths

### DIFF
--- a/samples/wire-ets.json
+++ b/samples/wire-ets.json
@@ -271,6 +271,9 @@
           ],
           "format": "string"
         },
+        "timestamp": {
+          "type": "string"
+        },
         "type": {
           "format": "string"
         }

--- a/src/generators/MethodGenerator.ts
+++ b/src/generators/MethodGenerator.ts
@@ -38,7 +38,7 @@ export class MethodGenerator {
     this.spec = spec;
     this.responses = responses;
 
-    const parameterMatch = url.match(/\{([^}]+)\}$/);
+    const parameterMatch = url.match(/\{([^}]+)\}/);
 
     if (parameterMatch) {
       this.parameterName = parameterMatch[1];

--- a/src/generators/ResourceGenerator.ts
+++ b/src/generators/ResourceGenerator.ts
@@ -1,4 +1,5 @@
 import {Path, Spec} from 'swagger-schema-official';
+import {camelCase} from '../util/StringUtil';
 import {MethodGenerator} from './MethodGenerator';
 import {TemplateGenerator} from './TemplateGenerator';
 
@@ -11,11 +12,15 @@ export class ResourceGenerator extends TemplateGenerator {
 
   constructor(fullyQualifiedName: string, resources: Record<string, Path>, spec: Spec) {
     super();
-    const stopIndex = fullyQualifiedName.lastIndexOf('/');
+    const directories = fullyQualifiedName.split('/');
 
-    if (stopIndex > -1) {
-      this.directory = fullyQualifiedName.substr(0, stopIndex);
-      this.name = fullyQualifiedName.substr(stopIndex + 1);
+    if (directories.length > 2) {
+      this.name = camelCase(directories.slice(1), true);
+      directories.pop();
+      this.directory = directories.join('/');
+    } else if (directories.length > 1) {
+      this.name = directories.pop()!;
+      this.directory = directories.join('/');
     } else {
       this.directory = '/';
       this.name = fullyQualifiedName;

--- a/src/util/StringUtil.ts
+++ b/src/util/StringUtil.ts
@@ -41,5 +41,5 @@ export function generateServiceName(url: string): string {
 }
 
 export function normalizeUrl(url: string): string {
-  return url.replace(/\/\{.*\}$/, '');
+  return url.replace(/\/\{.*\}/g, '');
 }


### PR DESCRIPTION
This PR will
- fix paths like `/instance/{instanceId}/archive` (they were not parsed correctly before)
- fix services with the same name in different directories