### PR TITLE
feat: Import service names as unique names

### DIFF
--- a/src/Swaxios.test.ts
+++ b/src/Swaxios.test.ts
@@ -2,7 +2,7 @@ import {Spec} from 'swagger-schema-official';
 import {exportServices} from './Swaxios';
 
 describe('exportServices', () => {
-  it('merges resources if their belong to the same service', async () => {
+  it('merges resources if they belong to the same service', async () => {
     const swaggerJson: Spec = {
       info: {
         description: '',

--- a/src/Swaxios.ts
+++ b/src/Swaxios.ts
@@ -58,6 +58,7 @@ async function generateClient(swaggerJson: Spec, outputDirectory: string): Promi
   await new APIClientGenerator(fileIndex, outputDirectory).write();
 
   fileIndex.files['APIClient'] = {
+    alternativeName: null,
     fullPath: path.resolve(outputDirectory, 'APIClient'),
     name: 'APIClient',
   };

--- a/src/generators/APIClientGenerator.test.ts
+++ b/src/generators/APIClientGenerator.test.ts
@@ -1,0 +1,44 @@
+import {DirEntry} from '../util/FileUtil';
+import {API, APIClientGenerator} from './APIClientGenerator';
+
+describe('ResourceGenerator', () => {
+  describe('constructor', () => {
+    it('creates unique service names', async () => {
+      const fileIndex: DirEntry = {
+        directories: {
+          login: {
+            directories: {},
+            files: {
+              AuthService: {
+                alternativeName: null,
+                fullPath: '/home/user/swaxios/api/login/AuthService',
+                name: 'AuthService',
+              },
+            },
+            fullPath: 'login',
+            name: 'login',
+          },
+          post: {
+            directories: {},
+            files: {
+              AuthService: {
+                alternativeName: 'AuthService1',
+                fullPath: '/home/user/swaxios/api/post/AuthService',
+                name: 'AuthService',
+              },
+            },
+            fullPath: 'post',
+            name: 'post',
+          },
+        },
+        files: {},
+        fullPath: '',
+        name: '',
+      };
+
+      const generator = new APIClientGenerator(fileIndex, '.');
+      const services = (await generator.generateAPI(fileIndex)) as Record<string, API>;
+      expect(services.login.authService).not.toBe(services.post.authService);
+    });
+  });
+});

--- a/src/generators/ResourceGenerator.ts
+++ b/src/generators/ResourceGenerator.ts
@@ -20,7 +20,7 @@ export class ResourceGenerator extends TemplateGenerator {
     const directories = fullyQualifiedName.split('/');
 
     if (directories.length > 2) {
-      this.name = camelCase([directories[directories.length - 1]], true);
+      this.name = camelCase(directories.slice(-1), true);
       directories.pop();
       this.directory = directories.join('/');
     } else if (directories.length > 1) {

--- a/src/templates/APIClient.hbs
+++ b/src/templates/APIClient.hbs
@@ -8,7 +8,10 @@ import axios, {AxiosInstance, AxiosRequestConfig} from 'axios';
 {{#each imports}}
 import {
   {{#each this.files}}
-  {{{this}}},
+    {{{this.name}}}
+    {{#if this.alternativeName}}
+      as {{{this.alternativeName}}}
+    {{/if}},
   {{/each}}
 } from './{{{this.dir}}}/';
 {{/each}}

--- a/src/util/FileUtil.test.ts
+++ b/src/util/FileUtil.test.ts
@@ -3,8 +3,8 @@ import * as FileUtil from './FileUtil';
 describe('getUniqueFileName', () => {
   it('creates unique file names', () => {
     const fileName = FileUtil.getUniqueFileName('MyFile');
-    const fileName1 = FileUtil.getUniqueFileName('MyFile1');
-    const fileName2 = FileUtil.getUniqueFileName('MyFile2');
+    const fileName1 = FileUtil.getUniqueFileName('MyFile');
+    const fileName2 = FileUtil.getUniqueFileName('MyFile');
     expect(fileName).toBe(null);
     expect(fileName1).toBe('MyFile1');
     expect(fileName2).toBe('MyFile2');

--- a/src/util/FileUtil.test.ts
+++ b/src/util/FileUtil.test.ts
@@ -1,0 +1,12 @@
+import * as FileUtil from './FileUtil';
+
+describe('getUniqueFileName', () => {
+  it('creates unique file names', () => {
+    const fileName = FileUtil.getUniqueFileName('MyFile');
+    const fileName1 = FileUtil.getUniqueFileName('MyFile1');
+    const fileName2 = FileUtil.getUniqueFileName('MyFile2');
+    expect(fileName).toBe(null);
+    expect(fileName1).toBe('MyFile1');
+    expect(fileName2).toBe('MyFile2');
+  });
+});

--- a/src/util/FileUtil.test.ts
+++ b/src/util/FileUtil.test.ts
@@ -2,11 +2,9 @@ import * as FileUtil from './FileUtil';
 
 describe('getUniqueFileName', () => {
   it('creates unique file names', () => {
-    const fileName = FileUtil.getUniqueFileName('MyFile');
-    const fileName1 = FileUtil.getUniqueFileName('MyFile');
-    const fileName2 = FileUtil.getUniqueFileName('MyFile');
-    expect(fileName).toBe(null);
-    expect(fileName1).toBe('MyFile1');
-    expect(fileName2).toBe('MyFile2');
+    expect(FileUtil.getUniqueFileName('MyFile')).toBe(null);
+    for (let i = 1; i <= 10; i++) {
+      expect(FileUtil.getUniqueFileName('MyFile')).toBe(`MyFile${i}`);
+    }
   });
 });

--- a/src/util/FileUtil.ts
+++ b/src/util/FileUtil.ts
@@ -22,15 +22,14 @@ export function getUniqueFileName(fileName: string): string | null {
     return null;
   }
 
-  let newName = fileName;
+  let alternativeFilename = fileName;
 
-  while (fileNames.includes(newName)) {
-    const indexNumberMatch = newName.match(/(\d+)$/);
+  while (fileNames.includes(alternativeFilename)) {
+    const indexNumberMatch = alternativeFilename.match(/(\d+)$/);
     const indexNumber = indexNumberMatch ? parseInt(indexNumberMatch[0], 10) + 1 : 1;
-    newName = `${fileName}${indexNumber}`;
+    alternativeFilename = `${fileName}${indexNumber}`;
   }
 
-  const alternativeFilename = newName;
   fileNames.push(alternativeFilename);
   return alternativeFilename;
 }

--- a/src/util/FileUtil.ts
+++ b/src/util/FileUtil.ts
@@ -16,15 +16,21 @@ export interface DirEntry {
 
 const fileNames: string[] = [];
 
-function getUniqueFileName(fileName: string, fileNames: string[]): string | null {
+export function getUniqueFileName(fileName: string): string | null {
   if (!fileNames.includes(fileName)) {
     fileNames.push(fileName);
     return null;
   }
 
-  const indexAndExtension = fileName.match(/(\d+)\.(\w+)$/);
-  const indexNumber = indexAndExtension ? parseInt(indexAndExtension[0], 10) + 1 : 1;
-  const alternativeFilename = `${fileName}${indexNumber}`;
+  let newName = fileName;
+
+  while (fileNames.includes(newName)) {
+    const indexNumberMatch = newName.match(/(\d+)$/);
+    const indexNumber = indexNumberMatch ? parseInt(indexNumberMatch[0], 10) + 1 : 1;
+    newName = `${fileName}${indexNumber}`;
+  }
+
+  const alternativeFilename = newName;
   fileNames.push(alternativeFilename);
   return alternativeFilename;
 }
@@ -48,7 +54,7 @@ export async function generateFileIndex(directory: string): Promise<DirEntry> {
 
       if (lstat.isFile()) {
         fileIndex.files[fileName] = {
-          alternativeName: getUniqueFileName(fileName, fileNames),
+          alternativeName: getUniqueFileName(fileName),
           fullPath: resolvedFile.replace('.ts', ''),
           name: fileName,
         };

--- a/src/util/FileUtil.ts
+++ b/src/util/FileUtil.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 export interface FileEntry {
+  alternativeName: string | null;
   fullPath: string;
   name: string;
 }
@@ -11,6 +12,21 @@ export interface DirEntry {
   fullPath: string;
   files: Record<string, FileEntry>;
   name: string;
+}
+
+const fileNames: string[] = [];
+
+function getUniqueFileName(fileName: string, fileNames: string[]): string | null {
+  if (!fileNames.includes(fileName)) {
+    fileNames.push(fileName);
+    return null;
+  }
+
+  const indexAndExtension = fileName.match(/(\d+)\.(\w+)$/);
+  const indexNumber = indexAndExtension ? parseInt(indexAndExtension[0], 10) + 1 : 1;
+  const alternativeFilename = `${fileName}${indexNumber}`;
+  fileNames.push(alternativeFilename);
+  return alternativeFilename;
 }
 
 export async function generateFileIndex(directory: string): Promise<DirEntry> {
@@ -32,6 +48,7 @@ export async function generateFileIndex(directory: string): Promise<DirEntry> {
 
       if (lstat.isFile()) {
         fileIndex.files[fileName] = {
+          alternativeName: getUniqueFileName(fileName, fileNames),
           fullPath: resolvedFile.replace('.ts', ''),
           name: fileName,
         };


### PR DESCRIPTION
If there is a `ClientsService` in two different directories, the second one will now get a unique name by adding an incremented number at the end.

**Before**:

![before](https://user-images.githubusercontent.com/5497598/58417179-4436ef00-8084-11e9-9128-6702315973a0.png)

**After**:

![after](https://user-images.githubusercontent.com/5497598/58417196-4ef18400-8084-11e9-93cc-c4302b0eccc0.png)
