### PR TITLE
feat: Support Bearer authorization callback in operations

### DIFF
--- a/src/Swaxios.test.ts
+++ b/src/Swaxios.test.ts
@@ -84,7 +84,7 @@ describe('writeClient', () => {
     expect(actual).toBe(expected);
   });
 
-  it('supports Bearer authentication', async () => {
+  it('supports Bearer authorization', async () => {
     const inputFile = path.resolve(__dirname, './test/snapshots/7-bearer-auth.json');
     await writeClient(inputFile, tempDir, true);
 

--- a/src/Swaxios.test.ts
+++ b/src/Swaxios.test.ts
@@ -83,6 +83,16 @@ describe('writeClient', () => {
 
     expect(actual).toBe(expected);
   });
+
+  it('supports Bearer authentication', async () => {
+    const inputFile = path.resolve(__dirname, './test/snapshots/7-bearer-auth.json');
+    await writeClient(inputFile, tempDir, true);
+
+    const actual = await fs.readFile(path.join(tempDir, 'rest/api/v1/ExchangeService.ts'), 'utf-8');
+    const expected = await fs.readFile(path.resolve(__dirname, './test/snapshots/7-bearer-auth.ts.fixture'), 'utf-8');
+
+    expect(actual).toBe(expected);
+  });
 });
 
 describe('exportServices', () => {

--- a/src/generators/MethodGenerator.test.ts
+++ b/src/generators/MethodGenerator.test.ts
@@ -123,7 +123,7 @@ describe('MethodGenerator', () => {
       expect(methodDefinition.normalizedUrl).toBe('/identity-providers');
       expect(methodDefinition.parameterMethod).toBe('postById');
       expect(methodDefinition.pathParameters[0]).toEqual({name: 'id', type: 'any'});
-      expect(methodDefinition.bodyParameters![0]).toEqual({name: 'body', required: false, type: '{ user: string }'});
+      expect(methodDefinition.bodyParameters[0]).toEqual({name: 'body', required: false, type: '{ user: string }'});
     });
   });
 });

--- a/src/generators/MethodGenerator.ts
+++ b/src/generators/MethodGenerator.ts
@@ -48,6 +48,7 @@ export class MethodGenerator {
   readonly bodyParameters: InternalParameter[];
   readonly descriptions?: Description[];
   readonly formattedUrl: string;
+  readonly hasBearerAuthentication: boolean;
   readonly method: HttpMethod;
   readonly needsDataObj: boolean;
   readonly normalizedUrl: string;
@@ -59,6 +60,7 @@ export class MethodGenerator {
   constructor(url: string, method: HttpMethod, operation: OpenAPIV2.OperationObject, spec: OpenAPIV2.Document) {
     this.url = url;
     this.operation = operation;
+    this.method = method;
     this.normalizedUrl = StringUtil.normalizeUrl(url);
     this.formattedUrl = `'${url}'`;
     this.spec = spec;
@@ -83,9 +85,7 @@ export class MethodGenerator {
     }
 
     const postFix = parameterMatch ? `By${StringUtil.camelCase(parameterMatch.splice(1), true)}` : 'All';
-    this.parameterMethod = this.operation.operationId || `${method}${postFix}`;
-
-    this.method = method;
+    this.parameterMethod = this.operation.operationId || `${this.method}${postFix}`;
 
     if (this.includesSuccessResponse(this.responses)) {
       this.returnType = this.buildResponseSchema();
@@ -98,6 +98,9 @@ export class MethodGenerator {
       this.method === HttpMethod.POST ||
       this.method === HttpMethod.PUT
     );
+
+    this.hasBearerAuthentication =
+      !!this.operation.security && this.operation.security.some(obj => Object.keys(obj).includes('Bearer'));
   }
 
   private includesSuccessResponse(

--- a/src/generators/MethodGenerator.ts
+++ b/src/generators/MethodGenerator.ts
@@ -48,7 +48,7 @@ export class MethodGenerator {
   readonly bodyParameters: InternalParameter[];
   readonly descriptions?: Description[];
   readonly formattedUrl: string;
-  readonly hasBearerAuthentication: boolean;
+  readonly requiresBearerAuthorization: boolean;
   readonly method: HttpMethod;
   readonly needsDataObj: boolean;
   readonly normalizedUrl: string;
@@ -99,7 +99,7 @@ export class MethodGenerator {
       this.method === HttpMethod.PUT
     );
 
-    this.hasBearerAuthentication =
+    this.requiresBearerAuthorization =
       !!this.operation.security && this.operation.security.some(obj => Object.keys(obj).includes('Bearer'));
   }
 

--- a/src/templates/Resource.hbs
+++ b/src/templates/Resource.hbs
@@ -29,7 +29,7 @@ export class {{{name}}} {
       {{#each this.bodyParameters}}
         {{{this.name}}}{{#isnt this.required true}}?{{/isnt}}: {{{this.type}}},
       {{/each}}
-      {{#if this.hasBearerAuthentication}}
+      {{#if this.requiresBearerAuthorization}}
         accessTokenCallback: () => Promise<string>,
       {{/if}}
       {{#if this.queryParameters.length}}
@@ -40,7 +40,7 @@ export class {{{name}}} {
         }
       {{/if}}
     ): Promise<{{{this.returnType}}}> => {
-      {{#if this.hasBearerAuthentication}}
+      {{#if this.requiresBearerAuthorization}}
         const accessToken = await accessTokenCallback();
       {{/if}}
       const config: AxiosRequestConfig = {
@@ -51,7 +51,7 @@ export class {{{name}}} {
             {{/each}}
           },
         {{/if}}
-        {{#if this.hasBearerAuthentication}}
+        {{#if this.requiresBearerAuthorization}}
           headers: {
             Authorization: `Bearer ${decodeURIComponent(accessToken)}`,
           },

--- a/src/templates/Resource.hbs
+++ b/src/templates/Resource.hbs
@@ -5,7 +5,7 @@
  * It should not be modified by hand.
  */
 
-import {AxiosInstance} from 'axios';
+import {AxiosInstance, AxiosRequestConfig} from 'axios';
 
 export class {{{name}}} {
   private readonly apiClient: AxiosInstance;
@@ -29,6 +29,9 @@ export class {{{name}}} {
       {{#each this.bodyParameters}}
         {{{this.name}}}{{#isnt this.required true}}?{{/isnt}}: {{{this.type}}},
       {{/each}}
+      {{#if this.hasBearerAuthentication}}
+        accessTokenCallback: () => Promise<string>,
+      {{/if}}
       {{#if this.queryParameters.length}}
         params?: {
           {{#each this.queryParameters}}
@@ -37,52 +40,34 @@ export class {{{name}}} {
         }
       {{/if}}
     ): Promise<{{{this.returnType}}}> => {
-      const resource = {{{this.formattedUrl}}};
-      {{#or this.queryParameters.length this.bodyParameters.length}}
-        {{#if this.needsDataObj}}
-          const config = {
-            {{#if this.bodyParameters.length}}
-              data: {
-                {{#each this.bodyParameters}}
-                  {{this.name}},
-                {{/each}}
-              },
-            {{/if}}
-            {{#if this.queryParameters.length}}
-              params,
-            {{/if}}
-          }
-        {{else}}
-          {{#eq this.bodyParameters.length 1}}
-            const data = {{{this.bodyParameters.[0].name}}};
-          {{/eq}}
-          {{#gt this.bodyParameters.length}}
-            const data = {
-              {{#each this.bodyParameters}}
-                {{{this.name}}},
-              {{/each}}
-            };
-          {{/gt}}
-          {{#if this.queryParameters.length}}
-            const config = {params};
-          {{/if}}
+      {{#if this.hasBearerAuthentication}}
+        const accessToken = await accessTokenCallback();
+      {{/if}}
+      const config: AxiosRequestConfig = {
+        {{#if this.bodyParameters.length}}
+          data: {
+            {{#each this.bodyParameters}}
+              ...{{this.name}},
+            {{/each}}
+          },
         {{/if}}
-      {{/or}}
+        {{#if this.hasBearerAuthentication}}
+          headers: {
+            Authorization: `Bearer ${decodeURIComponent(accessToken)}`,
+          },
+        {{/if}}
+        method: '{{{this.method}}}',
+        {{#if this.queryParameters.length}}
+          params,
+        {{/if}}
+        url: {{{this.formattedUrl}}},
+      }
       {{#eq this.returnType "void"}}
-        await this.apiClient.{{{this.method}}}
+        await this.apiClient.request
       {{else}}
-        const response = await this.apiClient.{{{this.method}}}<{{{this.returnType}}}>
+        const response = await this.apiClient.request<{{{this.returnType}}}>
       {{/eq}}
-      (
-        resource,
-        {{#or this.queryParameters.length this.bodyParameters.length}}
-          {{#if this.needsDataObj}}
-            config,
-          {{else}}
-            data,
-          {{/if}}
-        {{/or}}
-      );
+      (config);
       {{#isnt this.returnType "void"}}
         return response.data;
       {{/isnt}}

--- a/src/test/snapshots/1-query-param-description.ts.fixture
+++ b/src/test/snapshots/1-query-param-description.ts.fixture
@@ -5,7 +5,7 @@
  * It should not be modified by hand.
  */
 
-import {AxiosInstance} from 'axios';
+import {AxiosInstance, AxiosRequestConfig} from 'axios';
 
 export class ArchiveService {
   private readonly apiClient: AxiosInstance;
@@ -21,12 +21,17 @@ export class ArchiveService {
     instanceId: string,
     body: {archive: {}; conversationId: string}
   ): Promise<{instanceId: string; name: string}> => {
-    const resource = `/instance/${instanceId}/archive`;
-    const data = body;
-    const response = await this.apiClient.post<{
+    const config: AxiosRequestConfig = {
+      data: {
+        ...body,
+      },
+      method: 'post',
+      url: `/instance/${instanceId}/archive`,
+    };
+    const response = await this.apiClient.request<{
       instanceId: string;
       name: string;
-    }>(resource, data);
+    }>(config);
     return response.data;
   };
 }

--- a/src/test/snapshots/3-delete-by-id-number.ts.fixture
+++ b/src/test/snapshots/3-delete-by-id-number.ts.fixture
@@ -5,7 +5,7 @@
  * It should not be modified by hand.
  */
 
-import {AxiosInstance} from 'axios';
+import {AxiosInstance, AxiosRequestConfig} from 'axios';
 
 export class ExchangeService {
   private readonly apiClient: AxiosInstance;
@@ -15,7 +15,10 @@ export class ExchangeService {
   }
 
   deleteById = async (id: number): Promise<void> => {
-    const resource = `/api/v1/exchange/${id}`;
-    await this.apiClient.delete(resource);
+    const config: AxiosRequestConfig = {
+      method: 'delete',
+      url: `/api/v1/exchange/${id}`,
+    };
+    await this.apiClient.request(config);
   };
 }

--- a/src/test/snapshots/5-query-param-required.ts.fixture
+++ b/src/test/snapshots/5-query-param-required.ts.fixture
@@ -5,7 +5,7 @@
  * It should not be modified by hand.
  */
 
-import {AxiosInstance} from 'axios';
+import {AxiosInstance, AxiosRequestConfig} from 'axios';
 
 export class UserService {
   private readonly apiClient: AxiosInstance;
@@ -19,11 +19,12 @@ export class UserService {
     lastname: string;
     age?: number;
   }): Promise<string> => {
-    const resource = '/api/user';
-    const config = {
+    const config: AxiosRequestConfig = {
+      method: 'get',
       params,
+      url: '/api/user',
     };
-    const response = await this.apiClient.get<string>(resource, config);
+    const response = await this.apiClient.request<string>(config);
     return response.data;
   };
 }

--- a/src/test/snapshots/6-operationId.ts.fixture
+++ b/src/test/snapshots/6-operationId.ts.fixture
@@ -5,7 +5,7 @@
  * It should not be modified by hand.
  */
 
-import {AxiosInstance} from 'axios';
+import {AxiosInstance, AxiosRequestConfig} from 'axios';
 
 export class ExchangeService {
   private readonly apiClient: AxiosInstance;
@@ -15,7 +15,10 @@ export class ExchangeService {
   }
 
   deleteExchange = async (id: number): Promise<void> => {
-    const resource = `/api/v1/exchange/${id}`;
-    await this.apiClient.delete(resource);
+    const config: AxiosRequestConfig = {
+      method: 'delete',
+      url: `/api/v1/exchange/${id}`,
+    };
+    await this.apiClient.request(config);
   };
 }

--- a/src/test/snapshots/7-bearer-auth.json
+++ b/src/test/snapshots/7-bearer-auth.json
@@ -1,0 +1,44 @@
+{
+  "basePath": "/",
+  "info": {
+    "description": "",
+    "title": "",
+    "version": ""
+  },
+  "paths": {
+    "/api/v1/exchange/{id}": {
+      "delete": {
+        "operationId": "deleteExchange",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "number"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    }
+  },
+  "schemes": [
+    "http"
+  ],
+  "swagger": "2.0",
+  "tags": []
+}

--- a/src/test/snapshots/7-bearer-auth.ts.fixture
+++ b/src/test/snapshots/7-bearer-auth.ts.fixture
@@ -14,12 +14,18 @@ export class ExchangeService {
     this.apiClient = apiClient;
   }
 
-  deleteById = async (id: number): Promise<number> => {
+  deleteExchange = async (
+    id: number,
+    accessTokenCallback: () => Promise<string>
+  ): Promise<void> => {
+    const accessToken = await accessTokenCallback();
     const config: AxiosRequestConfig = {
+      headers: {
+        Authorization: `Bearer ${decodeURIComponent(accessToken)}`,
+      },
       method: 'delete',
       url: `/api/v1/exchange/${id}`,
     };
-    const response = await this.apiClient.request<number>(config);
-    return response.data;
+    await this.apiClient.request(config);
   };
 }


### PR DESCRIPTION
This supports adding a callback to an endpoint which uses Bearer authorization:

```ts
deleteExchange = async (
  id: number,
  accessTokenCallback: () => Promise<string>
): Promise<void> => {
  const accessToken = await accessTokenCallback();
  const config: AxiosRequestConfig = {
    headers: {
      Authorization: `Bearer ${decodeURIComponent(accessToken)}`,
    },
    method: 'delete',
    url: `/api/v1/exchange/${id}`,
  };
  await this.apiClient.request(config);
};
```

I also moved from `this.apiClient.[method]()` to `this.apiClient.request()` and moved the method to the axios request configuration.

This closes https://github.com/bennyn/swaxios/issues/62.