### PR TITLE
fix: Use original Swagger object and fix references

### DIFF
--- a/src/generators/MethodGenerator.ts
+++ b/src/generators/MethodGenerator.ts
@@ -223,7 +223,7 @@ export class MethodGenerator {
         console.warn(`No reference found for "${schema.$ref}".`);
         return TypeScriptType.EMPTY_OBJECT;
       }
-      const definition = schema.$ref.replace('#/definitions', '');
+      const definition = schema.$ref.replace('#/definitions/', '');
       properties = this.spec.definitions[definition].properties;
       requiredProperties = this.spec.definitions[definition].required;
       schemaType = this.spec.definitions[definition].type as string;

--- a/src/validator/SwaggerValidator.ts
+++ b/src/validator/SwaggerValidator.ts
@@ -2,5 +2,6 @@ import {OpenAPIV2} from 'openapi-types';
 import SwaggerParser from 'swagger-parser';
 
 export async function validateConfig(swaggerJson: OpenAPIV2.Document): Promise<void> {
-  await SwaggerParser.validate(swaggerJson);
+  const swaggerJsonCopy = JSON.parse(JSON.stringify(swaggerJson));
+  await SwaggerParser.validate(swaggerJsonCopy);
 }

--- a/src/validator/SwaggerValidator.ts
+++ b/src/validator/SwaggerValidator.ts
@@ -2,6 +2,8 @@ import {OpenAPIV2} from 'openapi-types';
 import SwaggerParser from 'swagger-parser';
 
 export async function validateConfig(swaggerJson: OpenAPIV2.Document): Promise<void> {
+  // let's create a copy because swagger-parser modifies the object,
+  // see https://github.com/APIDevTools/swagger-parser/issues/77
   const swaggerJsonCopy = JSON.parse(JSON.stringify(swaggerJson));
   await SwaggerParser.validate(swaggerJsonCopy);
 }


### PR DESCRIPTION
As it turns out, `swagger-parser` doesn't just parse the Swagger file, but also [modifies it](https://github.com/APIDevTools/swagger-parser/issues/77). By giving `swagger-parser` only a copy of our original Swagger object I noticed that the references were broken.