### PR TITLE
fix: Codeowners syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # In alphabetical order
-* @bennyn
-* @ffflorian
+* @bennyn @ffflorian


### PR DESCRIPTION
[The docs](https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file) state that multiple users should be in one line.